### PR TITLE
Kubernetes Recreate strategy instead of manual pod scale-down

### DIFF
--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -93,35 +93,6 @@ steps:
     event:
       - push
 
-- name: scale_down_pods_dev
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/kd
-  commands:
-  - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
-  - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
-  - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
-  - command -v kubectl >/dev/null 2>&1
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
-  environment:
-    NOTPROD_KUBE_NAMESPACE:
-      from_secret: NOTPROD_KUBE_NAMESPACE
-    NOTPROD_KUBE_SERVER:
-      from_secret: NOTPROD_KUBE_SERVER
-    NOTPROD_KUBE_TOKEN:
-      from_secret: NOTPROD_KUBE_TOKEN
-  when:
-    branch:
-      - master
-      - hotfix/*
-      - feature/*
-    event:
-      - promote
-      - push
-    target:
-      exclude:
-        - production
-
 - name: deploy_to_dev
   pull: if-not-exists
   image: quay.io/ukhomeofficedigital/kd
@@ -211,31 +182,6 @@ steps:
     target:
     - production
 
-- name: scale_down_pods_prod
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/kd
-  commands:
-  - export KUBE_SERVER=$${PROD_KUBE_SERVER}
-  - export KUBE_TOKEN=$${PROD_KUBE_TOKEN}
-  - export KUBE_NAMESPACE=$${PROD_KUBE_NAMESPACE}
-  - command -v kubectl >/dev/null 2>&1
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
-  environment:
-    PROD_KUBE_NAMESPACE:
-      from_secret: PROD_KUBE_NAMESPACE
-    PROD_KUBE_SERVER:
-      from_secret: PROD_KUBE_SERVER
-    PROD_KUBE_TOKEN:
-      from_secret: PROD_KUBE_TOKEN
-  when:
-    branch:
-    - master
-    - hotfix/*
-    event:
-    - promote
-    target:
-    - production
 
 - name: deploy_to_production
   pull: if-not-exists

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,6 @@ steps:
       - hotfix/*
       - feature/*
     event:
-      - promote
       - push
     target:
       exclude:

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/scale-down.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -95,7 +95,7 @@ steps:
 
 - name: scale_down_pods_dev
   pull: if-not-exists
-  image: *kd-image
+  image: quay.io/ukhomeofficedigital/kd
   commands:
   - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
   - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
@@ -212,7 +212,7 @@ steps:
 
 - name: scale_down_pods_prod
   pull: if-not-exists
-  image: *kd-image
+  image: quay.io/ukhomeofficedigital/kd
   commands:
   - export KUBE_SERVER=$${PROD_KUBE_SERVER}
   - export KUBE_TOKEN=$${PROD_KUBE_TOKEN}

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -93,6 +93,33 @@ steps:
     event:
       - push
 
+- name: scale_down_pods_dev
+  pull: if-not-exists
+  image: *kd-image
+  commands:
+  - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
+  - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
+  - command -v kubectl >/dev/null 2>&1
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
+  environment:
+    KUBE_NAMESPACE: dq-apps-notprod
+    NOTPROD_KUBE_SERVER:
+      from_secret: NOTPROD_KUBE_SERVER
+    NOTPROD_KUBE_TOKEN:
+      from_secret: NOTPROD_KUBE_TOKEN
+  when:
+    branch:
+      - master
+      - hotfix/*
+      - feature/*
+    event:
+      - promote
+      - push
+    target:
+      exclude:
+        - production
+
 - name: deploy_to_dev
   pull: if-not-exists
   image: quay.io/ukhomeofficedigital/kd
@@ -177,6 +204,30 @@ steps:
   when:
     branch:
     - master
+    event:
+    - promote
+    target:
+    - production
+
+- name: scale_down_pods_prod
+  pull: if-not-exists
+  image: *kd-image
+  commands:
+  - export KUBE_SERVER=$${PROD_KUBE_SERVER}
+  - export KUBE_TOKEN=$${PROD_KUBE_TOKEN}
+  - command -v kubectl >/dev/null 2>&1
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
+  environment:
+    KUBE_NAMESPACE: dq-apps
+    PROD_KUBE_SERVER:
+      from_secret: PROD_KUBE_SERVER
+    PROD_KUBE_TOKEN:
+      from_secret: PROD_KUBE_TOKEN
+  when:
+    branch:
+    - master
+    - hotfix/*
     event:
     - promote
     target:

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f scale-down.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -93,31 +93,7 @@ steps:
     event:
       - push
 
-- name: scale_down_pods_dev
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/kd
-  commands:
-  - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
-  - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
-  - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
-  - kd -f kube/scale-down.yml
-  environment:
-    NOTPROD_KUBE_NAMESPACE:
-      from_secret: NOTPROD_KUBE_NAMESPACE
-    NOTPROD_KUBE_SERVER:
-      from_secret: NOTPROD_KUBE_SERVER
-    NOTPROD_KUBE_TOKEN:
-      from_secret: NOTPROD_KUBE_TOKEN
-  when:
-    branch:
-      - master
-      - hotfix/*
-      - feature/*
-    event:
-      - push
-    target:
-      exclude:
-        - production
+
 
 - name: deploy_to_dev
   pull: if-not-exists
@@ -140,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
+  - kd -f kube/scale-down.yml kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -100,8 +100,7 @@ steps:
   - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
   - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
   - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
-  - command -v kubectl >/dev/null 2>&1
-  - kd -f kube/scale-down.ym
+  - kd -f kube/scale-down.yml
   environment:
     NOTPROD_KUBE_NAMESPACE:
       from_secret: NOTPROD_KUBE_NAMESPACE

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -101,8 +101,8 @@ steps:
   - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
   - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
   - command -v kubectl >/dev/null 2>&1
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-api-msk-consumer --replicas=0
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-api-msk-consumer --timeout=120s
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
   environment:
     NOTPROD_KUBE_NAMESPACE:
       from_secret: NOTPROD_KUBE_NAMESPACE

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/scale-down.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f scale-down.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/scale-down.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -101,8 +101,7 @@ steps:
   - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
   - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
   - command -v kubectl >/dev/null 2>&1
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
-  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
+  - kd -f kube/scale-down.ym
   environment:
     NOTPROD_KUBE_NAMESPACE:
       from_secret: NOTPROD_KUBE_NAMESPACE

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -99,11 +99,13 @@ steps:
   commands:
   - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
   - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
+  - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
   - command -v kubectl >/dev/null 2>&1
   - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
   - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
   environment:
-    KUBE_NAMESPACE: dq-apps-notprod
+    NOTPROD_KUBE_NAMESPACE:
+      from_secret: NOTPROD_KUBE_NAMESPACE
     NOTPROD_KUBE_SERVER:
       from_secret: NOTPROD_KUBE_SERVER
     NOTPROD_KUBE_TOKEN:
@@ -215,11 +217,13 @@ steps:
   commands:
   - export KUBE_SERVER=$${PROD_KUBE_SERVER}
   - export KUBE_TOKEN=$${PROD_KUBE_TOKEN}
+  - export KUBE_NAMESPACE=$${PROD_KUBE_NAMESPACE}
   - command -v kubectl >/dev/null 2>&1
   - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-oag-data-ingest --replicas=0
   - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-oag-data-ingest --timeout=120s
   environment:
-    KUBE_NAMESPACE: dq-apps
+    PROD_KUBE_NAMESPACE:
+      from_secret: PROD_KUBE_NAMESPACE
     PROD_KUBE_SERVER:
       from_secret: PROD_KUBE_SERVER
     PROD_KUBE_TOKEN:

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -93,7 +93,34 @@ steps:
     event:
       - push
 
-
+- name: scale_down_pods_dev
+  pull: if-not-exists
+  image: quay.io/ukhomeofficedigital/kd
+  commands:
+  - export KUBE_SERVER=$${NOTPROD_KUBE_SERVER}
+  - export KUBE_TOKEN=$${NOTPROD_KUBE_TOKEN}
+  - export KUBE_NAMESPACE=$${NOTPROD_KUBE_NAMESPACE}
+  - command -v kubectl >/dev/null 2>&1
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify scale deployment dq-api-msk-consumer --replicas=0
+  - kubectl --server="$${KUBE_SERVER}" --token="$${KUBE_TOKEN}" --namespace="$${KUBE_NAMESPACE}" --insecure-skip-tls-verify wait --for=delete pod -l name=dq-api-msk-consumer --timeout=120s
+  environment:
+    NOTPROD_KUBE_NAMESPACE:
+      from_secret: NOTPROD_KUBE_NAMESPACE
+    NOTPROD_KUBE_SERVER:
+      from_secret: NOTPROD_KUBE_SERVER
+    NOTPROD_KUBE_TOKEN:
+      from_secret: NOTPROD_KUBE_TOKEN
+  when:
+    branch:
+      - master
+      - hotfix/*
+      - feature/*
+    event:
+      - promote
+      - push
+    target:
+      exclude:
+        - production
 
 - name: deploy_to_dev
   pull: if-not-exists
@@ -116,7 +143,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/scale-down.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -116,7 +116,7 @@ steps:
   - export OAG_RDS_PASSWORD=$$NOTPROD_OAG_RDS_PASSWORD
   - export OAG_RDS_TABLE=$$NOTPROD_OAG_RDS_TABLE
   - export SLACK_WEBHOOK=$$NOTPROD_SLACK_WEBHOOK
-  - kd -f kube/scale-down.yml kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
+  - kd -f kube/pvc.yml -f kube/secret.yml -f kube/deployment.yml
   environment:
     ENV: notprod
     INSECURE_SKIP_TLS_VERIFY: true

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -43,15 +43,33 @@ RUN apk add --update py-pip && \
 
 # Install PM2
 RUN apk add --update nodejs npm
-RUN npm install -g pm2 && \
-    npm update -g pm2
-# ────────────────────────────────────────────────
-# FIX THE CVEs: upgrade the vulnerable Node packages
-# ────────────────────────────────────────────────
-RUN npm install -g --no-save \
-    js-yaml@4.1.1 \
-    lodash@4.18.0\
-    systeminformation@5.31.0
+#RUN npm install -g pm2 && \
+#    npm update -g pm2
+
+# ─────────────────────────────────────────────────────────────────
+# FIX CVEs & OPTIMIZE SIZE: Universal dependency override & cleanup
+# ─────────────────────────────────────────────────────────────────
+RUN mkdir -p /tmp/npm-patch && cd /tmp/npm-patch && \
+    # 1. Create a root manifest enforcing secure versions across the entire build tree
+    echo '{\
+      "overrides": {\
+        "systeminformation": "5.31.6",\
+        "lodash": "4.18.0",\
+        "ws": "8.20.1",\
+        "diff": "8.0.3",\
+        "serialize-javascript": "7.0.5"\
+      }\
+    }' > package.json && \
+    # 2. Install PM2 and required packages globally using the strict overrides config
+    # (Removed redundant 'npm update' command which bypassed the overrides file)
+    npm install -g pm2 js-yaml@4.1.1 lodash@4.18.0 systeminformation@5.31.6 && \
+    # 3. ─── CLEANUP SECTOR (Enforces strict size limits) ───
+    cd / && rm -rf /tmp/npm-patch && \
+    npm cache clean --force && \
+    rm -rf /root/.npm/_cacache && \
+    rm -rf /root/.node-gyp && \
+    # Strip optional testing/doc folders brought in by npm
+    find "$(npm root -g)" -type d \( -name "test" -o -name "doc" -o -name "docs" \) -exec rm -rf {} + 2>/dev/null || true
 
 RUN apk update --quiet \
     && apk upgrade --quiet

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -7,6 +7,8 @@ metadata:
     {{ if eq .ENV "notprod" }}downscaler/uptime: Mon-Fri 07:00-18:30 Europe/London{{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: dq-oag-data-ingest

--- a/kube/scale-down.yml
+++ b/kube/scale-down.yml
@@ -1,6 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: dq-oag-data-ingest
-spec:
-  replicas: 0

--- a/kube/scale-down.yml
+++ b/kube/scale-down.yml
@@ -1,5 +1,4 @@
----
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dq-oag-data-ingest

--- a/kube/scale-down.yml
+++ b/kube/scale-down.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: dq-oag-data-ingest
+spec:
+  replicas: 0


### PR DESCRIPTION
Summary

This change simplifies the deployment process by replacing the manual pod scale-down approach with the Kubernetes Recreate deployment strategy.

Changes

- Added strategy.type: Recreate to kube/deployment.yml
- Fix CVE's by updating Dockerfile